### PR TITLE
Force rewrite

### DIFF
--- a/private/libshared.nim
+++ b/private/libshared.nim
@@ -1,4 +1,4 @@
-import logging, os, sequtils, strutils, critbits, algorithm
+import logging, os, sequtils, critbits, algorithm
 import neverwinter/resman, neverwinter/resdir, neverwinter/key,
   neverwinter/erf, neverwinter/gff, neverwinter/resfile
 

--- a/private/libupdate.nim
+++ b/private/libupdate.nim
@@ -1,8 +1,7 @@
 import options, logging, critbits, std/sha1, strutils, sequtils,
-  os, ospaths, algorithm, math, times, json, sets, tables
+  os, math, times, json, sets, tables
 
-import neverwinter/erf, neverwinter/resfile, neverwinter/resdir,
-  neverwinter/gff, neverwinter/resman, neverwinter/key
+import neverwinter/gff, neverwinter/resman
 
 import libmanifest
 import libshared

--- a/private/libupdate.nim
+++ b/private/libupdate.nim
@@ -87,8 +87,12 @@ proc reindex*(rootDirectory: string,
     if dm.hasKey(0):
       moduleDescription = dm[0]
 
-  info "Reading existing data in storage"
-  var writtenHashes = getFilesInStorage(rootDirectory)
+  var writtenHashes: CritBitTree[string]
+  if forceWriteIfExists:
+    info "Force-Rewrite: Ignoring data in storage"
+  else:
+    info "Reading existing data in storage"
+    writtenHashes = getFilesInStorage(rootDirectory)
 
   info "Calculating complete manifest size"
   let totalbytes: int64 = entriesToExpose.mapIt(int64 resman[it].get().len).sum()


### PR DESCRIPTION
passing the -f arg previously had no effect, as while it would read the arg and set the `forceWriteIfExists` appropriately, that bool was never used to implement any action.

Earliest intercession is to simply pretend there were no files in storage if -f is passed.

(Also misc cleanup of unused imports) 