### PR TITLE
Error out on the write process if a file is too large for the client

### DIFF
--- a/private/libupdate.nim
+++ b/private/libupdate.nim
@@ -90,8 +90,13 @@ proc reindex*(rootDirectory: string,
   info "Reading existing data in storage"
   var writtenHashes = getFilesInStorage(rootDirectory)
 
+  info "Checking for files that are too large"
+  let allFileSize = entriesToExpose.mapIt(int64 resman[it].get().len)
+  if allFileSize.max() >= 15728640:
+    raise newException(ValueError, "You have a resource that is greater than 15MB in size which the client is unable download")
+
   info "Calculating complete manifest size"
-  let totalbytes: int64 = entriesToExpose.mapIt(int64 resman[it].get().len).sum()
+  let totalbytes = allFileSize.sum()
   info "Generating data for ", totalfiles, " resrefs, ",
     formatSize(totalbytes), " (This might take a while, we need to checksum it all)"
 

--- a/private/libupdate.nim
+++ b/private/libupdate.nim
@@ -93,7 +93,7 @@ proc reindex*(rootDirectory: string,
   info "Checking for files that are too large"
   let allFileSize = entriesToExpose.mapIt(int64 resman[it].get().len)
   if allFileSize.max() >= 15728640:
-    raise newException(ValueError, "You have a resource that is greater than 15MB in size which the client is unable download")
+    raise newException(ValueError, "You have a resource that is greater than 15MB in size which the client is unable to download")
 
   info "Calculating complete manifest size"
   let totalbytes = allFileSize.sum()


### PR DESCRIPTION
Can be a pain to not notice you've used a file too large as a resource until you attempt to connect to your server for the first time.