### PR TITLE
fix typo in nwsync_prune info message output

### DIFF
--- a/nwsync_prune.nim
+++ b/nwsync_prune.nim
@@ -113,7 +113,7 @@ proc pruneUnreferencedFiles*(rootDirectory: string) =
   let missing = referencedHashes - inStorageHashes
 
   info "Orphans (not referenced, but in storage): ", orphans.len
-  info "Missing (referenced, but in not storage): ", missing.len
+  info "Missing (referenced, but not in storage): ", missing.len
 
   for m in missing:
     let mfh = toSeq(referenced[m].items).


### PR DESCRIPTION
I think the message should be this way around.