### PR TITLE
update neverwinter to 1.4.5 for support of new restypes

### DIFF
--- a/nwsync.nimble
+++ b/nwsync.nimble
@@ -6,7 +6,7 @@ description   = "NWSync Repository Management utilities"
 license       = "MIT"
 
 requires "nim >= 1.4.8"
-requires "neverwinter >= 1.4.2"
+requires "neverwinter >= 1.4.5"
 requires "docopt >= 0.6.8"
 
 skipExt = @["nim"]


### PR DESCRIPTION
Wanted to add a .jpg to nwsync and noticed this. Compiling with new neverwinter.nim worked.